### PR TITLE
Fix incorrect heap size value for boxed slice

### DIFF
--- a/get-size2/src/lib.rs
+++ b/get-size2/src/lib.rs
@@ -511,13 +511,11 @@ impl GetSize for std::path::PathBuf {
 
 impl GetSize for &std::path::Path {}
 
-impl<T> GetSize for Box<[T]> {
+impl<T> GetSize for Box<[T]>
+where
+    T: GetSize,
+{
     fn get_heap_size(&self) -> usize {
-        let mut total = 0;
-        for item in self {
-            total += item.get_size();
-        }
-
-        total
+        self.iter().map(GetSize::get_size).sum()
     }
 }

--- a/get-size2/tests/mod.rs
+++ b/get-size2/tests/mod.rs
@@ -243,3 +243,16 @@ fn derive_newtype() {
     let test = TestNewType(0);
     assert_eq!(u64::get_stack_size(), test.get_size());
 }
+
+#[test]
+fn boxed_slice() {
+    use std::mem::size_of;
+    let boxed = vec![1u8; 10].into_boxed_slice();
+    assert_eq!(boxed.get_heap_size(), size_of::<u8>() * boxed.len());
+
+    let boxed = vec![1u32; 10].into_boxed_slice();
+    assert_eq!(boxed.get_heap_size(), size_of::<u32>() * boxed.len());
+
+    let boxed = vec![&1u8; 10].into_boxed_slice();
+    assert_eq!(boxed.get_heap_size(), size_of::<&u8>() * boxed.len());
+}


### PR DESCRIPTION
Previously the `GetSize` impl for a boxed slice didn't have a bound on `T`, so `get_size` was being called on `&T` instead of `T`. This meant that the size of each element was always being calculated to the size of a reference. This change fixes that and adds a test.

Closes #1 