### PR TITLE
🌍 Optionally implement `GetSize` for `url`

### DIFF
--- a/crates/get-size2/Cargo.toml
+++ b/crates/get-size2/Cargo.toml
@@ -19,15 +19,17 @@ get-size-derive2 = { workspace = true, optional = true }
 
 chrono = { version = "0.4", default-features = false, optional = true }
 chrono-tz = { version = "0.10", default-features = false, optional = true }
+url = { version = "2", default-features = false, optional = true }
 
 [dev-dependencies]
-get-size2 = { path = ".", features = ["derive", "chrono", "chrono-tz"] }
+get-size2 = { path = ".", features = ["derive", "chrono", "chrono-tz", "url"] }
 
 [features]
 default = []
 derive = ["get-size-derive2"]
 chrono = ["dep:chrono"]
 chrono-tz = ["dep:chrono-tz"]
+url = ["dep:url"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/get-size2/src/lib.rs
+++ b/crates/get-size2/src/lib.rs
@@ -542,3 +542,10 @@ mod chrono {
 
 #[cfg(feature = "chrono-tz")]
 impl GetSize for chrono_tz::TzOffset {}
+
+#[cfg(feature = "url")]
+impl GetSize for url::Url {
+    fn get_heap_size(&self) -> usize {
+        self.as_str().len()
+    }
+}

--- a/crates/get-size2/src/test.rs
+++ b/crates/get-size2/src/test.rs
@@ -282,3 +282,11 @@ fn chrono_tz() {
         .unwrap(); // `2014-07-08T09:10:11Z`
     assert_eq!(datetime.offset().get_heap_size(), 0);
 }
+
+#[test]
+fn url() {
+    const URL_STR: &str = "https://example.com/path?a=b&c=d";
+
+    let url = url::Url::parse(URL_STR).unwrap();
+    assert_eq!(url.get_heap_size(), URL_STR.len());
+}


### PR DESCRIPTION
This PR adds a new optional dependency to automatically implement `GetSize` support for the `url` crate.

I noticed I had to do `#[get-size(with_fn = "..")]` for `Url` quite often, so I figured I'd PR it upstream instead.