### PR TITLE
🕰️ Optionally implement `GetSize` for `chrono` and `chrono-tz`

### DIFF
--- a/crates/get-size2/Cargo.toml
+++ b/crates/get-size2/Cargo.toml
@@ -17,12 +17,17 @@ workspace = true
 [dependencies]
 get-size-derive2 = { workspace = true, optional = true }
 
+chrono = { version = "0.4", default-features = false, optional = true }
+chrono-tz = { version = "0.10", default-features = false, optional = true }
+
 [dev-dependencies]
-get-size2 = { path = ".", features = ["derive"] }
+get-size2 = { path = ".", features = ["derive", "chrono", "chrono-tz"] }
 
 [features]
 default = []
 derive = ["get-size-derive2"]
+chrono = ["dep:chrono"]
+chrono-tz = ["dep:chrono-tz"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/get-size2/src/lib.rs
+++ b/crates/get-size2/src/lib.rs
@@ -518,3 +518,27 @@ where
         self.iter().map(GetSize::get_size).sum()
     }
 }
+
+#[cfg(feature = "chrono")]
+mod chrono {
+    use crate::GetSize;
+
+    impl GetSize for chrono::NaiveDate {}
+    impl GetSize for chrono::NaiveTime {}
+    impl GetSize for chrono::NaiveDateTime {}
+    impl GetSize for chrono::Utc {}
+    impl GetSize for chrono::FixedOffset {}
+    impl GetSize for chrono::TimeDelta {}
+
+    impl<Tz: chrono::TimeZone> GetSize for chrono::DateTime<Tz>
+    where
+        Tz::Offset: GetSize,
+    {
+        fn get_heap_size(&self) -> usize {
+            GetSize::get_heap_size(self.offset())
+        }
+    }
+}
+
+#[cfg(feature = "chrono-tz")]
+impl GetSize for chrono_tz::TzOffset {}

--- a/crates/get-size2/src/test.rs
+++ b/crates/get-size2/src/test.rs
@@ -256,3 +256,29 @@ fn boxed_slice() {
     let boxed = vec![&1u8; 10].into_boxed_slice();
     assert_eq!(boxed.get_heap_size(), size_of::<&u8>() * boxed.len());
 }
+
+#[test]
+fn chrono() {
+    use chrono::TimeZone;
+
+    let timedelta = chrono::TimeDelta::seconds(5);
+    assert_eq!(timedelta.get_heap_size(), 0);
+
+    let datetime = chrono::Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap(); // `2014-07-08T09:10:11Z`
+    assert_eq!(datetime.naive_utc().get_heap_size(), 0);
+    assert_eq!(datetime.naive_utc().date().get_heap_size(), 0);
+    assert_eq!(datetime.naive_utc().time().get_heap_size(), 0);
+    assert_eq!(datetime.timezone().get_heap_size(), 0);
+    assert_eq!(datetime.fixed_offset().timezone().get_heap_size(), 0);
+    assert_eq!(datetime.get_heap_size(), 0);
+}
+
+#[test]
+fn chrono_tz() {
+    use chrono::TimeZone;
+
+    let datetime = chrono_tz::UTC
+        .with_ymd_and_hms(2014, 7, 8, 9, 10, 11)
+        .unwrap(); // `2014-07-08T09:10:11Z`
+    assert_eq!(datetime.offset().get_heap_size(), 0);
+}


### PR DESCRIPTION
This PR adds a new optional dependency to automatically implement `GetSize` support for the `chrono` and `chrono-tz` crate.

I noticed I had to do `#[get-size(with_fn = "..")]` for `chrono` types quite often, so I figured I'd PR it upstream instead.