### PR TITLE
Add top-level `heap_size` function

### DIFF
--- a/crates/get-size2/src/lib.rs
+++ b/crates/get-size2/src/lib.rs
@@ -27,6 +27,11 @@ pub use tracker::*;
 #[cfg(test)]
 mod test;
 
+/// Determines how many bytes the object occupies inside the heap.
+pub fn heap_size<T: GetSize>(value: &T) -> usize {
+    value.get_heap_size()
+}
+
 /// Determine the size in bytes an object occupies inside RAM.
 pub trait GetSize: Sized {
     /// Determines how may bytes this object occupies inside the stack.


### PR DESCRIPTION
This is just a little helper that makes it easier to reference the `get_heap_size` function, especially in macros (e.g. `size_fn = get_size2::GetSize::get_heap_size`).