### PR TITLE
🗺️ Optionally implement `GetSize` for `indexmap`

### DIFF
--- a/crates/get-size2/Cargo.toml
+++ b/crates/get-size2/Cargo.toml
@@ -20,31 +20,35 @@ get-size-derive2 = { workspace = true, optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 chrono = { version = "0.4", default-features = false, optional = true }
 chrono-tz = { version = "0.10", default-features = false, optional = true }
+compact_str = { version = "0.9", default-features = false, optional = true }
 hashbrown = { version = "0.15", default-features = false, optional = true }
+indexmap = { version = "2.10.0", default-features = false, optional = true }
 smallvec = { version = "1", default-features = false, optional = true }
 url = { version = "2", default-features = false, optional = true }
-compact_str = { version = "0.9", default-features = false, optional = true }
 
 [dev-dependencies]
 get-size2 = { path = ".", features = [
-    "bytes",
     "derive",
+    "bytes",
     "chrono",
     "chrono-tz",
     "compact-str",
     "hashbrown",
+    "indexmap",
     "smallvec",
     "url",
 ] }
 
 [features]
 default = []
-bytes = ["dep:bytes"]
 derive = ["get-size-derive2"]
+
+bytes = ["dep:bytes"]
 chrono = ["dep:chrono"]
 chrono-tz = ["dep:chrono-tz"]
 compact-str = ["dep:compact_str"]
 hashbrown = ["dep:hashbrown"]
+indexmap = ["dep:indexmap"]
 smallvec = ["dep:smallvec"]
 url = ["dep:url"]
 

--- a/crates/get-size2/src/lib.rs
+++ b/crates/get-size2/src/lib.rs
@@ -697,3 +697,30 @@ impl GetSize for compact_str::CompactString {
         }
     }
 }
+
+#[cfg(feature = "indexmap")]
+impl<K, V, S> GetSize for indexmap::IndexMap<K, V, S>
+where
+    K: GetSize,
+    V: GetSize,
+    S: std::hash::BuildHasher,
+{
+    fn get_heap_size(&self) -> usize {
+        self.capacity() * <(K, V)>::get_stack_size()
+            + self
+                .iter()
+                .map(|(k, v)| k.get_heap_size() + v.get_heap_size())
+                .sum::<usize>()
+    }
+}
+
+#[cfg(feature = "indexmap")]
+impl<T, S> GetSize for indexmap::IndexSet<T, S>
+where
+    T: GetSize,
+{
+    fn get_heap_size(&self) -> usize {
+        self.capacity() * <T>::get_stack_size()
+            + self.iter().map(GetSize::get_heap_size).sum::<usize>()
+    }
+}

--- a/crates/get-size2/src/test.rs
+++ b/crates/get-size2/src/test.rs
@@ -442,3 +442,27 @@ fn test_ignore_attribute_on_enum_field() {
         "Expected heap size contribution from Vec<u8> to be at least 100"
     );
 }
+
+#[test]
+fn test_indexmap() {
+    use std::hash::RandomState;
+
+    const VALUE_STR: &str = "A very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooonng string.";
+
+    let hasher = RandomState::new();
+
+    let mut map = indexmap::IndexMap::with_capacity_and_hasher(1, hasher);
+    assert_eq!(map.get_heap_size(), 40);
+    map.insert(VALUE_STR, String::from(VALUE_STR));
+    assert!(map.get_heap_size() >= size_of::<(&'static str, String)>() + VALUE_STR.len());
+
+    let mut map = indexmap::IndexMap::<i32, String, RandomState>::default();
+    assert_eq!(map.get_heap_size(), 0);
+    map.insert(0, String::from(VALUE_STR));
+    assert!(map.get_heap_size() >= size_of::<(i32, String)>() + VALUE_STR.len());
+
+    let mut set = indexmap::IndexSet::<String, RandomState>::default();
+    assert_eq!(set.get_heap_size(), 0);
+    set.insert(String::from(VALUE_STR));
+    assert!(set.get_heap_size() >= size_of::<String>() + VALUE_STR.len());
+}


### PR DESCRIPTION
This PR adds a new optional dependency to automatically implement `GetSize` support for the `indexmap` crate.