### PR TITLE
Fix heap size calculation for spilled `SmallVec`

### DIFF
--- a/crates/get-size2/src/lib.rs
+++ b/crates/get-size2/src/lib.rs
@@ -683,7 +683,10 @@ where
             return self.iter().map(GetSize::get_heap_size).sum();
         }
 
-        self.iter().map(GetSize::get_size).sum()
+        let mut total = self.iter().map(GetSize::get_size).sum();
+        let additional: usize = self.capacity() - self.len();
+        total += additional * A::Item::get_stack_size();
+        total
     }
 }
 

--- a/crates/get-size2/src/test.rs
+++ b/crates/get-size2/src/test.rs
@@ -388,6 +388,13 @@ fn smallvec() {
 
     assert_eq!(
         vec.get_heap_size(),
+        ITEM_STR.len() + std::mem::size_of::<String>() * vec.capacity()
+    );
+
+    vec.shrink_to_fit();
+
+    assert_eq!(
+        vec.get_heap_size(),
         ITEM_STR.len() + std::mem::size_of::<String>() * 3
     );
 }


### PR DESCRIPTION
Similar to `Vec`'s, the `SmallVec` heap size needs to account for the reserved but empty elements if the `SmallVec` spilled to the heap.
