### PR TITLE
Fix heap size calculation for spilled `CompactStr`

### DIFF
--- a/crates/get-size2/src/lib.rs
+++ b/crates/get-size2/src/lib.rs
@@ -691,7 +691,7 @@ where
 impl GetSize for compact_str::CompactString {
     fn get_heap_size(&self) -> usize {
         if self.is_heap_allocated() {
-            self.len()
+            self.capacity()
         } else {
             0
         }

--- a/crates/get-size2/src/test.rs
+++ b/crates/get-size2/src/test.rs
@@ -339,14 +339,20 @@ fn once_lock_get_size() {
     );
 }
 
+#[test]
 fn compact_str() {
     const STR: &str = "Hello world";
-    const LONG_STR: &str = "A much looooonger string.";
+    const LONG_STR: &str = "A much looooonger string that exceeds 24 bytes.";
 
     let value = compact_str::CompactString::from(STR);
     assert_eq!(value.get_heap_size(), 0);
 
-    let value = compact_str::CompactString::from(LONG_STR);
+    let mut value = compact_str::CompactString::from(LONG_STR);
+    assert_eq!(value.get_heap_size(), value.capacity());
+
+    value.shrink_to_fit();
+
+    assert_eq!(value.len(), value.capacity());
     assert_eq!(value.get_heap_size(), LONG_STR.len());
 }
 


### PR DESCRIPTION
The size on the heap is equal to the string's capacity not its length.
