### PR TITLE
Implement GetSize for Rc and Arc slices with tests

### DIFF
--- a/crates/get-size2/src/lib.rs
+++ b/crates/get-size2/src/lib.rs
@@ -579,9 +579,27 @@ impl GetSize for Box<str> {
     }
 }
 
+impl<T> GetSize for Rc<[T]>
+where
+    T: GetSize,
+{
+    fn get_heap_size(&self) -> usize {
+        self.iter().map(GetSize::get_size).sum()
+    }
+}
+
 impl GetSize for Rc<str> {
     fn get_heap_size(&self) -> usize {
         self.len()
+    }
+}
+
+impl<T> GetSize for Arc<[T]>
+where
+    T: GetSize,
+{
+    fn get_heap_size(&self) -> usize {
+        self.iter().map(GetSize::get_size).sum()
     }
 }
 

--- a/crates/get-size2/src/test.rs
+++ b/crates/get-size2/src/test.rs
@@ -260,6 +260,12 @@ fn boxed_slice() {
 
     let boxed = vec![&1u8; 10].into_boxed_slice();
     assert_eq!(boxed.get_heap_size(), size_of::<&u8>() * boxed.len());
+
+    let rc = Rc::<[u8]>::from([1u8; 10]);
+    assert_eq!(rc.get_heap_size(), size_of::<u8>() * rc.len());
+
+    let arc = Arc::<[u8]>::from([1u8; 10]);
+    assert_eq!(arc.get_heap_size(), size_of::<u8>() * arc.len());
 }
 
 #[test]


### PR DESCRIPTION
Add functionality to calculate the heap size for `Rc` and `Arc` slices, along with corresponding tests to verify the implementation.