### PR TITLE
Fix missing LICENSE file in the published get-size2 crate

### DIFF
--- a/crates/get-size2/LICENSE
+++ b/crates/get-size2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Denis Kerp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
I copied the `LICENSE` file already present at the root of the repository and in `crates/get-size-derive2/` into `crates/get-size2`.

An alternative approach would have been to use symbolic links to the top-level `LICENSE` file.

----

Before this PR, working in `crates/get-size2`:

```
$ cargo publish --dry-run
[…]
$ tar -tzf ../../target/package/get-size2-0.7.0.crate
get-size2-0.7.0/.cargo_vcs_info.json
get-size2-0.7.0/Cargo.lock
get-size2-0.7.0/Cargo.toml
get-size2-0.7.0/Cargo.toml.orig
get-size2-0.7.0/README.md
get-size2-0.7.0/src/lib.md
get-size2-0.7.0/src/lib.rs
get-size2-0.7.0/src/test.rs
get-size2-0.7.0/src/tracker.rs
```

After this PR, working in `crates/get-size2`:

```
$ cargo publish --dry-run
[…]
$ tar -tzf ../../target/package/get-size2-0.7.0.crate
get-size2-0.7.0/.cargo_vcs_info.json
get-size2-0.7.0/Cargo.lock
get-size2-0.7.0/Cargo.toml
get-size2-0.7.0/Cargo.toml.orig
get-size2-0.7.0/LICENSE
get-size2-0.7.0/README.md
get-size2-0.7.0/src/lib.md
get-size2-0.7.0/src/lib.rs
get-size2-0.7.0/src/test.rs
get-size2-0.7.0/src/tracker.rs
```