### PR TITLE
Add parking_lot feature with GetSize + GetSizeTracker impls

### DIFF
--- a/crates/get-size2/Cargo.toml
+++ b/crates/get-size2/Cargo.toml
@@ -24,6 +24,7 @@ compact_str = { version = "0.9", default-features = false, optional = true }
 hashbrown = { version = "0.17", default-features = false, optional = true }
 indexmap = { version = "2.14", default-features = false, optional = true }
 ordermap = { version = "1.2", default-features = false, optional = true }
+parking_lot = { version = "0.12", default-features = false, optional = true }
 smallvec = { version = "1", default-features = false, optional = true }
 thin-vec = { version = "0.2", default-features = false, optional = true }
 url = { version = "2", default-features = false, optional = true }
@@ -38,6 +39,7 @@ get-size2 = { path = ".", features = [
     "hashbrown",
     "indexmap",
     "ordermap",
+    "parking_lot",
     "smallvec",
     "thin-vec",
     "url",
@@ -54,6 +56,7 @@ compact-str = ["dep:compact_str"]
 hashbrown = ["dep:hashbrown"]
 indexmap = ["dep:indexmap"]
 ordermap = ["dep:ordermap"]
+parking_lot = ["dep:parking_lot"]
 smallvec = ["dep:smallvec"]
 thin-vec = ["dep:thin-vec"]
 url = ["dep:url"]

--- a/crates/get-size2/src/impls/feature/mod.rs
+++ b/crates/get-size2/src/impls/feature/mod.rs
@@ -14,6 +14,8 @@ mod hashbrown;
 mod indexmap;
 #[cfg(feature = "ordermap")]
 mod ordermap;
+#[cfg(feature = "parking_lot")]
+mod parking_lot;
 #[cfg(feature = "smallvec")]
 mod smallvec;
 #[cfg(feature = "thin-vec")]

--- a/crates/get-size2/src/impls/feature/parking_lot.rs
+++ b/crates/get-size2/src/impls/feature/parking_lot.rs
@@ -1,0 +1,56 @@
+use crate::{GetSize, GetSizeTracker};
+
+// parking_lot's Mutex/RwLock are infallible (no poisoning) so these are
+// simpler than the std::sync variants in `impls/sync_impls.rs` — no
+// `unwrap_or_else(PoisonError::into_inner)` recovery needed.
+
+impl<T> GetSize for parking_lot::Mutex<T>
+where
+    T: GetSize,
+{
+    fn get_heap_size_with_tracker<Tr: GetSizeTracker>(&self, tracker: Tr) -> (usize, Tr) {
+        let guard = self.lock();
+        T::get_heap_size_with_tracker(&*guard, tracker)
+    }
+}
+
+impl<T> GetSize for parking_lot::RwLock<T>
+where
+    T: GetSize,
+{
+    fn get_heap_size_with_tracker<Tr: GetSizeTracker>(&self, tracker: Tr) -> (usize, Tr) {
+        let guard = self.read();
+        T::get_heap_size_with_tracker(&*guard, tracker)
+    }
+}
+
+// Tracker-side mirrors of the std::sync impls in `crate::tracker`.
+// Letting a `parking_lot::Mutex<Tracker>` work as a tracker keeps API
+// parity with the existing `Mutex<Tracker>` / `RwLock<Tracker>` /
+// `Arc<Mutex<Tracker>>` / `Arc<RwLock<Tracker>>` patterns.
+
+impl<T: GetSizeTracker> GetSizeTracker for parking_lot::Mutex<T> {
+    fn track<A>(&mut self, addr: *const A) -> bool {
+        GetSizeTracker::track(self.get_mut(), addr)
+    }
+}
+
+impl<T: GetSizeTracker> GetSizeTracker for parking_lot::RwLock<T> {
+    fn track<A>(&mut self, addr: *const A) -> bool {
+        GetSizeTracker::track(self.get_mut(), addr)
+    }
+}
+
+impl<T: GetSizeTracker> GetSizeTracker for std::sync::Arc<parking_lot::Mutex<T>> {
+    fn track<A>(&mut self, addr: *const A) -> bool {
+        let mut guard = self.lock();
+        GetSizeTracker::track(&mut *guard, addr)
+    }
+}
+
+impl<T: GetSizeTracker> GetSizeTracker for std::sync::Arc<parking_lot::RwLock<T>> {
+    fn track<A>(&mut self, addr: *const A) -> bool {
+        let mut guard = self.write();
+        GetSizeTracker::track(&mut *guard, addr)
+    }
+}

--- a/crates/get-size2/src/tests/feature.rs
+++ b/crates/get-size2/src/tests/feature.rs
@@ -164,6 +164,27 @@ fn test_indexmap() {
 }
 
 #[test]
+fn parking_lot() {
+    use std::sync::Arc;
+
+    const S: &str = "Hello world";
+
+    let mut v = Vec::with_capacity(1);
+    v.push(String::from(S));
+    let expected = size_of::<String>() + S.len();
+
+    let m = parking_lot::Mutex::new(v.clone());
+    assert_eq!(m.get_heap_size(), expected);
+
+    let r = parking_lot::RwLock::new(v);
+    assert_eq!(r.get_heap_size(), expected);
+
+    let tracker = Arc::new(parking_lot::Mutex::new(StandardTracker::new()));
+    let (size, _) = r.get_heap_size_with_tracker(tracker);
+    assert_eq!(size, expected);
+}
+
+#[test]
 fn test_ordermap() {
     use std::hash::RandomState;
 

--- a/crates/get-size2/src/tests/feature.rs
+++ b/crates/get-size2/src/tests/feature.rs
@@ -164,7 +164,7 @@ fn test_indexmap() {
 }
 
 #[test]
-fn parking_lot() {
+fn test_parking_lot() {
     use std::sync::Arc;
 
     const S: &str = "Hello world";


### PR DESCRIPTION
Adds an optional `parking_lot` feature with `GetSize` and `GetSizeTracker` impls for `parking_lot::Mutex` and `parking_lot::RwLock` (plus `Arc<parking_lot::Mutex<_>>` / `Arc<parking_lot::RwLock<_>>` on the tracker side) — mirroring the existing `std::sync` coverage in `src/impls/sync_impls.rs` and `src/tracker.rs`.

## Motivation

`parking_lot` is widely used in async / heavy-concurrency Rust services for its smaller `sizeof` and faster uncontended fast path. Without native impls, downstream users have to either:

- Annotate every lock-bearing field with `#[get_size(size_fn = ...)]`
- Wrap each `parking_lot::RwLock<T>` in a local newtype just to add `impl GetSize`
- Patch the crate locally

A feature-gated impl in the upstream crate fixes this for everyone.

## Notes

- `parking_lot::Mutex::lock()` and `RwLock::read()` are infallible (no poisoning), so the impls are simpler than the `std::sync` ones — no `unwrap_or_else(PoisonError::into_inner)` recovery needed.
- New file at `src/impls/feature/parking_lot.rs`, following the existing per-feature module pattern (alongside `bytes.rs`, `chrono.rs`, etc.).
- Cargo.toml gets `parking_lot = { version = "0.12", default-features = false, optional = true }` and a matching `parking_lot = ["dep:parking_lot"]` feature flag.
- Default build is unchanged. Verified: `cargo build`, `cargo build --features get-size2/parking_lot` both clean.

Drafted while building a memory-reporting metric in a service that uses parking_lot end-to-end. Filing as draft pending your feedback on shape — happy to add tests, restructure, or split into separate PRs for the GetSize half vs the tracker half if you'd prefer.
