### PR TITLE
Add half feature with GetSize impls for f16 and bf16

### DIFF
--- a/crates/get-size2/Cargo.toml
+++ b/crates/get-size2/Cargo.toml
@@ -21,6 +21,7 @@ bytes = { version = "1", default-features = false, optional = true }
 chrono = { version = "0.4", default-features = false, optional = true }
 chrono-tz = { version = "0.10", default-features = false, optional = true }
 compact_str = { version = "0.9", default-features = false, optional = true }
+half = { version = "2", default-features = false, optional = true }
 hashbrown = { version = "0.17", default-features = false, optional = true }
 indexmap = { version = "2.14", default-features = false, optional = true }
 ordermap = { version = "1.2", default-features = false, optional = true }
@@ -35,6 +36,7 @@ get-size2 = { path = ".", features = [
     "chrono",
     "chrono-tz",
     "compact-str",
+    "half",
     "hashbrown",
     "indexmap",
     "ordermap",
@@ -51,6 +53,7 @@ bytes = ["dep:bytes"]
 chrono = ["dep:chrono"]
 chrono-tz = ["dep:chrono-tz"]
 compact-str = ["dep:compact_str"]
+half = ["dep:half"]
 hashbrown = ["dep:hashbrown"]
 indexmap = ["dep:indexmap"]
 ordermap = ["dep:ordermap"]

--- a/crates/get-size2/src/impls/feature/half.rs
+++ b/crates/get-size2/src/impls/feature/half.rs
@@ -1,0 +1,4 @@
+use crate::GetSize;
+
+impl GetSize for half::f16 {}
+impl GetSize for half::bf16 {}

--- a/crates/get-size2/src/impls/feature/mod.rs
+++ b/crates/get-size2/src/impls/feature/mod.rs
@@ -8,6 +8,8 @@ mod chrono;
 mod chrono_tz;
 #[cfg(feature = "compact-str")]
 mod compact_str;
+#[cfg(feature = "half")]
+mod half;
 #[cfg(feature = "hashbrown")]
 mod hashbrown;
 #[cfg(feature = "indexmap")]

--- a/crates/get-size2/src/tests/feature.rs
+++ b/crates/get-size2/src/tests/feature.rs
@@ -67,6 +67,17 @@ fn compact_str() {
 }
 
 #[test]
+fn test_half() {
+    let a = half::f16::from_f32(1.5);
+    assert_eq!(a.get_heap_size(), 0);
+    assert_eq!(a.get_size(), size_of::<half::f16>());
+
+    let b = half::bf16::from_f32(1.5);
+    assert_eq!(b.get_heap_size(), 0);
+    assert_eq!(b.get_size(), size_of::<half::bf16>());
+}
+
+#[test]
 fn hashbrown() {
     use std::hash::{BuildHasher, RandomState};
 


### PR DESCRIPTION
## Summary
- Add optional `half` Cargo feature exposing `GetSize` impls for `half::f16` and `half::bf16`.
- Both types are 2-byte POD with no heap allocation, so the trait's default `get_heap_size_with_tracker` (returns 0) is sufficient — matches the pattern used for `chrono::NaiveDate` etc.

## Cross-check
Mirrors the surface used by [`mem_dbg-rs`](https://github.com/zommiommy/mem_dbg-rs) (`impl_size_of!(True; half::f16, half::bf16)`): same two types, no SIMD wrappers (`f16x4`, etc.), heap size = 0.

## Test plan
- [x] `cargo test -p get-size2 --features half test_half`
- [x] `cargo build -p get-size2 --all-features`
