### PR TITLE
Add dashmap feature with GetSize impls for DashMap and DashSet

### DIFF
--- a/crates/get-size2/Cargo.toml
+++ b/crates/get-size2/Cargo.toml
@@ -21,6 +21,7 @@ bytes = { version = "1", default-features = false, optional = true }
 chrono = { version = "0.4", default-features = false, optional = true }
 chrono-tz = { version = "0.10", default-features = false, optional = true }
 compact_str = { version = "0.9", default-features = false, optional = true }
+dashmap = { version = "6", default-features = false, optional = true }
 hashbrown = { version = "0.17", default-features = false, optional = true }
 indexmap = { version = "2.14", default-features = false, optional = true }
 ordermap = { version = "1.2", default-features = false, optional = true }
@@ -35,6 +36,7 @@ get-size2 = { path = ".", features = [
     "chrono",
     "chrono-tz",
     "compact-str",
+    "dashmap",
     "hashbrown",
     "indexmap",
     "ordermap",
@@ -51,6 +53,7 @@ bytes = ["dep:bytes"]
 chrono = ["dep:chrono"]
 chrono-tz = ["dep:chrono-tz"]
 compact-str = ["dep:compact_str"]
+dashmap = ["dep:dashmap"]
 hashbrown = ["dep:hashbrown"]
 indexmap = ["dep:indexmap"]
 ordermap = ["dep:ordermap"]

--- a/crates/get-size2/src/impls/feature/dashmap.rs
+++ b/crates/get-size2/src/impls/feature/dashmap.rs
@@ -1,0 +1,37 @@
+use std::hash::{BuildHasher, Hash};
+
+use crate::{GetSize, GetSizeTracker};
+
+impl<K, V, S> GetSize for dashmap::DashMap<K, V, S>
+where
+    K: GetSize + Eq + Hash,
+    V: GetSize,
+    S: BuildHasher + Clone,
+{
+    fn get_heap_size_with_tracker<Tr: GetSizeTracker>(&self, tracker: Tr) -> (usize, Tr) {
+        let (size, tracker) = self.iter().fold((0, tracker), |(size, tracker), entry| {
+            let (k_size, tracker) = K::get_heap_size_with_tracker(entry.key(), tracker);
+            let (v_size, tracker) = V::get_heap_size_with_tracker(entry.value(), tracker);
+            (size + k_size + v_size, tracker)
+        });
+
+        let allocation_size = self.capacity() * <(K, V)>::get_stack_size();
+        (size + allocation_size, tracker)
+    }
+}
+
+impl<T, S> GetSize for dashmap::DashSet<T, S>
+where
+    T: GetSize + Eq + Hash,
+    S: BuildHasher + Clone,
+{
+    fn get_heap_size_with_tracker<Tr: GetSizeTracker>(&self, tracker: Tr) -> (usize, Tr) {
+        let (size, tracker) = self.iter().fold((0, tracker), |(size, tracker), entry| {
+            let (elem_size, tracker) = T::get_heap_size_with_tracker(entry.key(), tracker);
+            (size + elem_size, tracker)
+        });
+
+        let allocation_size = self.capacity() * T::get_stack_size();
+        (size + allocation_size, tracker)
+    }
+}

--- a/crates/get-size2/src/impls/feature/mod.rs
+++ b/crates/get-size2/src/impls/feature/mod.rs
@@ -8,6 +8,8 @@ mod chrono;
 mod chrono_tz;
 #[cfg(feature = "compact-str")]
 mod compact_str;
+#[cfg(feature = "dashmap")]
+mod dashmap;
 #[cfg(feature = "hashbrown")]
 mod hashbrown;
 #[cfg(feature = "indexmap")]

--- a/crates/get-size2/src/tests/feature.rs
+++ b/crates/get-size2/src/tests/feature.rs
@@ -67,6 +67,21 @@ fn compact_str() {
 }
 
 #[test]
+fn test_dashmap() {
+    const VALUE_STR: &str = "Hello world";
+
+    let map: dashmap::DashMap<i32, String> = dashmap::DashMap::new();
+    assert_eq!(map.get_heap_size(), 0);
+    map.insert(0, String::from(VALUE_STR));
+    assert!(map.get_heap_size() >= size_of::<(i32, String)>() + VALUE_STR.len());
+
+    let set: dashmap::DashSet<String> = dashmap::DashSet::new();
+    assert_eq!(set.get_heap_size(), 0);
+    set.insert(String::from(VALUE_STR));
+    assert!(set.get_heap_size() >= size_of::<String>() + VALUE_STR.len());
+}
+
+#[test]
 fn hashbrown() {
     use std::hash::{BuildHasher, RandomState};
 


### PR DESCRIPTION
## Summary
- Add optional `dashmap` Cargo feature exposing `GetSize` impls for `dashmap::DashMap` and `dashmap::DashSet`.
- Mirrors the std `HashMap` / `HashSet` impl in `impls/collections.rs`: iterate entries (under DashMap's per-shard read locks), sum each key/value's heap size, plus `capacity() * size_of::<(K, V)>()` for the bucket allocation.

## Notes
- Neither `get-size2` nor [`mem_dbg-rs`](https://github.com/zommiommy/mem_dbg-rs) had `dashmap` support before this — no upstream reference impl to cross-check against.
- `default-features = false` on the dashmap dep matches the convention used by the other optional deps in this crate.

## Test plan
- [x] `cargo test -p get-size2 --features dashmap test_dashmap`
- [x] `cargo test --all-features` (36 unit + 8 derive doctests + 12 lib doctests, all green)
