### PR TITLE
feat: Add roaring feature with GetSize impls for RoaringBitmap and RoaringTreemap

### DIFF
--- a/crates/get-size2/Cargo.toml
+++ b/crates/get-size2/Cargo.toml
@@ -27,6 +27,7 @@ hashbrown = { version = "0.17", default-features = false, optional = true }
 indexmap = { version = "2.14", default-features = false, optional = true }
 ordermap = { version = "1.2", default-features = false, optional = true }
 parking_lot = { version = "0.12", default-features = false, optional = true }
+roaring = { version = "0.11", default-features = false, optional = true }
 smallvec = { version = "1", default-features = false, optional = true }
 thin-vec = { version = "0.2", default-features = false, optional = true }
 url = { version = "2", default-features = false, optional = true }
@@ -44,6 +45,7 @@ get-size2 = { path = ".", features = [
     "indexmap",
     "ordermap",
     "parking_lot",
+    "roaring",
     "smallvec",
     "thin-vec",
     "url",
@@ -63,6 +65,7 @@ hashbrown = ["dep:hashbrown"]
 indexmap = ["dep:indexmap"]
 ordermap = ["dep:ordermap"]
 parking_lot = ["dep:parking_lot"]
+roaring = ["dep:roaring"]
 smallvec = ["dep:smallvec"]
 thin-vec = ["dep:thin-vec"]
 url = ["dep:url"]

--- a/crates/get-size2/src/impls/feature/mod.rs
+++ b/crates/get-size2/src/impls/feature/mod.rs
@@ -20,6 +20,8 @@ mod indexmap;
 mod ordermap;
 #[cfg(feature = "parking_lot")]
 mod parking_lot;
+#[cfg(feature = "roaring")]
+mod roaring;
 #[cfg(feature = "smallvec")]
 mod smallvec;
 #[cfg(feature = "thin-vec")]

--- a/crates/get-size2/src/impls/feature/roaring.rs
+++ b/crates/get-size2/src/impls/feature/roaring.rs
@@ -1,35 +1,25 @@
 use crate::{GetSize, GetSizeTracker};
 
-// `RoaringBitmap` stores 32-bit integers in "containers" of three
-// flavors (array, bitset, run), held in a private `Vec<Container>`.
-// Container allocations aren't reachable from outside the crate, but
-// `RoaringBitmap::statistics()` walks them internally and reports
-// per-flavor byte totals (capacity-based for array/run containers,
-// fixed 8 KiB for bitset). We sum those.
-//
-// Not counted (both small relative to container contents):
-// - Outer `Vec<Container>` slot allocation. `Container` is `pub(crate)`,
-//   so its size isn't accessible here. Max 65 536 containers per bitmap.
-// - Per-container key/tag fields.
+// Container allocations live in a private `Vec<Container>`; `statistics()`
+// is the only public proxy for their byte totals. Per-container key/tag
+// fields and the outer `Vec<Container>` slots are not counted — bounded
+// by 65 536 containers per bitmap, negligible vs. up to ~512 MiB of
+// container payload.
 
 impl GetSize for roaring::RoaringBitmap {
-    fn get_heap_size_with_tracker<T: GetSizeTracker>(&self, tracker: T) -> (usize, T) {
+    fn get_heap_size_with_tracker<Tr: GetSizeTracker>(&self, tracker: Tr) -> (usize, Tr) {
         let s = self.statistics();
         let bytes =
             s.n_bytes_array_containers + s.n_bytes_bitset_containers + s.n_bytes_run_containers;
-        // A single RoaringBitmap is bounded by 65 536 containers × 8 KiB
-        // (~512 MiB), so this fits in `usize` on every supported target.
-        // Saturate as a defensive fallback rather than panicking.
+        // u64 → usize: bounded ~512 MiB so fits everywhere; saturate
+        // defensively in release, surface the invariant breach in debug.
+        debug_assert!(bytes <= usize::MAX as u64);
         (usize::try_from(bytes).unwrap_or(usize::MAX), tracker)
     }
 }
 
-// `RoaringTreemap` is internally `BTreeMap<u32, RoaringBitmap>`. The
-// map is private, but `bitmaps()` is a public iterator over
-// `(u32, &RoaringBitmap)` pairs, which is enough to sum the contained
-// bitmaps. Mirrors the `BTreeMap<K, V>` impl in `collections.rs`:
-// per-entry it adds the stack-size + heap-size of both K and V, and
-// does not attempt to account for BTreeMap node padding.
+// Mirrors the `BTreeMap<K, V>` impl in `collections.rs` — per-entry
+// stack + heap of both K and V, no node-padding accounting.
 
 impl GetSize for roaring::RoaringTreemap {
     fn get_heap_size_with_tracker<Tr: GetSizeTracker>(&self, tracker: Tr) -> (usize, Tr) {

--- a/crates/get-size2/src/impls/feature/roaring.rs
+++ b/crates/get-size2/src/impls/feature/roaring.rs
@@ -1,0 +1,44 @@
+use crate::{GetSize, GetSizeTracker};
+
+// `RoaringBitmap` stores 32-bit integers in "containers" of three
+// flavors (array, bitset, run), held in a private `Vec<Container>`.
+// Container allocations aren't reachable from outside the crate, but
+// `RoaringBitmap::statistics()` walks them internally and reports
+// per-flavor byte totals (capacity-based for array/run containers,
+// fixed 8 KiB for bitset). We sum those.
+//
+// Not counted (both small relative to container contents):
+// - Outer `Vec<Container>` slot allocation. `Container` is `pub(crate)`,
+//   so its size isn't accessible here. Max 65 536 containers per bitmap.
+// - Per-container key/tag fields.
+
+impl GetSize for roaring::RoaringBitmap {
+    fn get_heap_size_with_tracker<T: GetSizeTracker>(&self, tracker: T) -> (usize, T) {
+        let s = self.statistics();
+        let bytes =
+            s.n_bytes_array_containers + s.n_bytes_bitset_containers + s.n_bytes_run_containers;
+        // A single RoaringBitmap is bounded by 65 536 containers × 8 KiB
+        // (~512 MiB), so this fits in `usize` on every supported target.
+        // Saturate as a defensive fallback rather than panicking.
+        (usize::try_from(bytes).unwrap_or(usize::MAX), tracker)
+    }
+}
+
+// `RoaringTreemap` is internally `BTreeMap<u32, RoaringBitmap>`. The
+// map is private, but `bitmaps()` is a public iterator over
+// `(u32, &RoaringBitmap)` pairs, which is enough to sum the contained
+// bitmaps. Mirrors the `BTreeMap<K, V>` impl in `collections.rs`:
+// per-entry it adds the stack-size + heap-size of both K and V, and
+// does not attempt to account for BTreeMap node padding.
+
+impl GetSize for roaring::RoaringTreemap {
+    fn get_heap_size_with_tracker<Tr: GetSizeTracker>(&self, tracker: Tr) -> (usize, Tr) {
+        self.bitmaps()
+            .fold((0, tracker), |(size, tracker), (key, bitmap)| {
+                let (key_size, tracker) = u32::get_size_with_tracker(&key, tracker);
+                let (bm_size, tracker) =
+                    roaring::RoaringBitmap::get_size_with_tracker(bitmap, tracker);
+                (size + key_size + bm_size, tracker)
+            })
+    }
+}

--- a/crates/get-size2/src/tests/feature.rs
+++ b/crates/get-size2/src/tests/feature.rs
@@ -254,6 +254,20 @@ fn test_roaring_bitmap() {
     let stats = wide.statistics();
     assert!(stats.n_bitset_containers >= 1);
     assert!(wide.get_heap_size() as u64 >= stats.n_bytes_bitset_containers);
+
+    // Run containers are produced by `optimize()` when a container has
+    // long dense runs. Verify we count run-container bytes too.
+    let mut run = (0..10_000).collect::<roaring::RoaringBitmap>();
+    run.optimize();
+    let stats = run.statistics();
+    assert!(stats.n_run_containers >= 1);
+    assert!(run.get_heap_size() as u64 >= stats.n_bytes_run_containers);
+
+    // Tracker-variant: threading a real tracker through must return the
+    // same size as the no-tracker path.
+    let tracker = StandardTracker::new();
+    let (size, _) = wide.get_heap_size_with_tracker(tracker);
+    assert_eq!(size, wide.get_heap_size());
 }
 
 #[test]
@@ -274,4 +288,10 @@ fn test_roaring_treemap() {
     }
     assert_eq!(bitmap_count, 2);
     assert_eq!(tm.get_heap_size(), expected_inner);
+
+    // Tracker-variant: threading a tracker through the BTreeMap walk
+    // must match the no-tracker path.
+    let tracker = StandardTracker::new();
+    let (size, _) = tm.get_heap_size_with_tracker(tracker);
+    assert_eq!(size, tm.get_heap_size());
 }

--- a/crates/get-size2/src/tests/feature.rs
+++ b/crates/get-size2/src/tests/feature.rs
@@ -249,11 +249,17 @@ fn test_roaring_bitmap() {
     assert!(dense.get_heap_size() > 0);
 
     // Bitmap container kicks in past ~4096 entries; verify we count
-    // the fixed 8 KiB allocation.
+    // the fixed 8 KiB allocation. Equality against the sum of all three
+    // flavor totals catches regressions that drop a flavor.
     let wide: roaring::RoaringBitmap = (0..5000).collect();
     let stats = wide.statistics();
     assert!(stats.n_bitset_containers >= 1);
-    assert!(wide.get_heap_size() as u64 >= stats.n_bytes_bitset_containers);
+    assert_eq!(
+        wide.get_heap_size() as u64,
+        stats.n_bytes_array_containers
+            + stats.n_bytes_bitset_containers
+            + stats.n_bytes_run_containers
+    );
 
     // Run containers are produced by `optimize()` when a container has
     // long dense runs. Verify we count run-container bytes too.
@@ -261,7 +267,12 @@ fn test_roaring_bitmap() {
     run.optimize();
     let stats = run.statistics();
     assert!(stats.n_run_containers >= 1);
-    assert!(run.get_heap_size() as u64 >= stats.n_bytes_run_containers);
+    assert_eq!(
+        run.get_heap_size() as u64,
+        stats.n_bytes_array_containers
+            + stats.n_bytes_bitset_containers
+            + stats.n_bytes_run_containers
+    );
 
     // Tracker-variant: threading a real tracker through must return the
     // same size as the no-tracker path.
@@ -275,10 +286,14 @@ fn test_roaring_treemap() {
     let empty = roaring::RoaringTreemap::new();
     assert_eq!(empty.get_heap_size(), 0);
 
-    // Two high-32-bit partitions → two inner RoaringBitmaps.
+    // Two high-32-bit partitions → two inner RoaringBitmaps. The second
+    // partition holds many values so the per-bitmap heap size is
+    // non-trivial (exercises propagation through the BTreeMap walk).
     let mut tm = roaring::RoaringTreemap::new();
     tm.insert(1);
-    tm.insert((1u64 << 32) + 1);
+    for v in 0..5000u64 {
+        tm.insert((1u64 << 32) + v);
+    }
     let mut bitmap_count = 0;
     let mut expected_inner: usize = 0;
     for (_, bitmap) in tm.bitmaps() {

--- a/crates/get-size2/src/tests/feature.rs
+++ b/crates/get-size2/src/tests/feature.rs
@@ -232,3 +232,46 @@ fn test_ordermap() {
     set.insert(String::from(VALUE_STR));
     assert!(set.get_heap_size() >= size_of::<String>() + VALUE_STR.len());
 }
+
+#[test]
+fn test_roaring_bitmap() {
+    // Empty bitmap: no containers, no allocations.
+    let empty = roaring::RoaringBitmap::new();
+    assert_eq!(empty.get_heap_size(), 0);
+
+    // Dense run that fits in one array container: should equal what
+    // `statistics()` reports for an array container — `capacity * 4`.
+    let dense: roaring::RoaringBitmap = (1..100).collect();
+    let stats = dense.statistics();
+    assert_eq!(stats.n_containers, 1);
+    assert_eq!(stats.n_array_containers, 1);
+    assert_eq!(dense.get_heap_size() as u64, stats.n_bytes_array_containers);
+    assert!(dense.get_heap_size() > 0);
+
+    // Bitmap container kicks in past ~4096 entries; verify we count
+    // the fixed 8 KiB allocation.
+    let wide: roaring::RoaringBitmap = (0..5000).collect();
+    let stats = wide.statistics();
+    assert!(stats.n_bitset_containers >= 1);
+    assert!(wide.get_heap_size() as u64 >= stats.n_bytes_bitset_containers);
+}
+
+#[test]
+fn test_roaring_treemap() {
+    let empty = roaring::RoaringTreemap::new();
+    assert_eq!(empty.get_heap_size(), 0);
+
+    // Two high-32-bit partitions → two inner RoaringBitmaps.
+    let mut tm = roaring::RoaringTreemap::new();
+    tm.insert(1);
+    tm.insert((1u64 << 32) + 1);
+    let mut bitmap_count = 0;
+    let mut expected_inner: usize = 0;
+    for (_, bitmap) in tm.bitmaps() {
+        bitmap_count += 1;
+        expected_inner +=
+            bitmap.get_heap_size() + size_of::<u32>() + size_of::<roaring::RoaringBitmap>();
+    }
+    assert_eq!(bitmap_count, 2);
+    assert_eq!(tm.get_heap_size(), expected_inner);
+}

--- a/crates/get-size2/src/tests/feature.rs
+++ b/crates/get-size2/src/tests/feature.rs
@@ -309,6 +309,8 @@ fn test_roaring_treemap() {
     let tracker = StandardTracker::new();
     let (size, _) = tm.get_heap_size_with_tracker(tracker);
     assert_eq!(size, tm.get_heap_size());
+}
+
 fn test_orx_concurrent_vec() {
     use orx_concurrent_vec::{ConcurrentElement, ConcurrentVec};
 


### PR DESCRIPTION
## Summary

Adds a `roaring` feature with `GetSize` impls for `roaring::RoaringBitmap` and `roaring::RoaringTreemap`, following the established pattern from the `dashmap`/`half`/`parking_lot` features (#46, #47, #48).

## Implementation

- **`RoaringBitmap`**: sums `statistics().n_bytes_{array,bitset,run}_containers`. The `Statistics` API already walks every container internally and reports per-flavor byte totals (`capacity()`-based for array and run, fixed 8 KiB for bitset), so no internal access to private container types is needed.
  - Not counted (both small relative to container contents and documented at the impl): the outer `Vec<Container>` slot allocation (`Container` is `pub(crate)`, so its size isn't accessible from outside the crate) and per-container tag/key fields.
- **`RoaringTreemap`**: internally a `BTreeMap<u32, RoaringBitmap>`. The map is private but the `bitmaps()` method exposes a public iterator over `(u32, &RoaringBitmap)`. Mirrors the existing `BTreeMap<K, V>` impl in `collections.rs` — per-entry adds stack-size + heap-size of both key and value, doesn't attempt to account for BTreeMap node padding.

## Tests

- `test_roaring_bitmap`: empty, array container, bitset container, run container (via `optimize()`), tracker-variant path.
- `test_roaring_treemap`: empty, two-partition treemap matching the sum of contained bitmaps, tracker-variant path.

## Notes

- Feature name `roaring` matches the published crate name on crates.io (the `-rs` is only in the GitHub repo name, same convention as `parking_lot` whose repo is `Amanieu/parking_lot`).
- `default-features = false` on the dep to preserve `no_std`-compatibility for downstream users.
