### PR TITLE
feat: Add orx-concurrent-vec feature with GetSize impl for ConcurrentVec

### DIFF
--- a/crates/get-size2/Cargo.toml
+++ b/crates/get-size2/Cargo.toml
@@ -26,6 +26,7 @@ half = { version = "2", default-features = false, optional = true }
 hashbrown = { version = "0.17", default-features = false, optional = true }
 indexmap = { version = "2.14", default-features = false, optional = true }
 ordermap = { version = "1.2", default-features = false, optional = true }
+orx-concurrent-vec = { version = "3.10", default-features = false, optional = true }
 parking_lot = { version = "0.12", default-features = false, optional = true }
 smallvec = { version = "1", default-features = false, optional = true }
 thin-vec = { version = "0.2", default-features = false, optional = true }
@@ -43,6 +44,7 @@ get-size2 = { path = ".", features = [
     "hashbrown",
     "indexmap",
     "ordermap",
+    "orx-concurrent-vec",
     "parking_lot",
     "smallvec",
     "thin-vec",
@@ -62,6 +64,7 @@ half = ["dep:half"]
 hashbrown = ["dep:hashbrown"]
 indexmap = ["dep:indexmap"]
 ordermap = ["dep:ordermap"]
+orx-concurrent-vec = ["dep:orx-concurrent-vec"]
 parking_lot = ["dep:parking_lot"]
 smallvec = ["dep:smallvec"]
 thin-vec = ["dep:thin-vec"]

--- a/crates/get-size2/src/impls/feature/mod.rs
+++ b/crates/get-size2/src/impls/feature/mod.rs
@@ -18,6 +18,8 @@ mod hashbrown;
 mod indexmap;
 #[cfg(feature = "ordermap")]
 mod ordermap;
+#[cfg(feature = "orx-concurrent-vec")]
+mod orx_concurrent_vec;
 #[cfg(feature = "parking_lot")]
 mod parking_lot;
 #[cfg(feature = "smallvec")]

--- a/crates/get-size2/src/impls/feature/orx_concurrent_vec.rs
+++ b/crates/get-size2/src/impls/feature/orx_concurrent_vec.rs
@@ -1,0 +1,30 @@
+use orx_concurrent_vec::{ConcurrentElement, ConcurrentVec, IntoConcurrentPinnedVec};
+
+use crate::{GetSize, GetSizeTracker};
+
+// `ConcurrentVec<T, P>` is backed by a `PinnedVec` of `ConcurrentElement<T>`
+// slots; each slot is a `ConcurrentElement<T>` (an atomic-state wrapper
+// around `T`) sized at `size_of::<ConcurrentElement<T>>()`. Heap layout
+// matches `Vec`: `capacity()` × per-slot size, plus the recursive heap
+// of each occupied element. This mirrors the `Vec<T>` impl pattern in
+// `collections.rs`.
+//
+// Not counted: per-fragment metadata in the backing `SplitVec`
+// (fragment pointer/length pairs). For a `Doubling` growth strategy
+// this is bounded by ~`log2(capacity)` fragments — tens of bytes total
+// regardless of corpus size.
+
+impl<T, P> GetSize for ConcurrentVec<T, P>
+where
+    T: GetSize,
+    P: IntoConcurrentPinnedVec<ConcurrentElement<T>>,
+{
+    fn get_heap_size_with_tracker<Tr: GetSizeTracker>(&self, tracker: Tr) -> (usize, Tr) {
+        let (heap, tracker) = self.iter().fold((0usize, tracker), |(size, tr), elem| {
+            let (elem_size, tr) = elem.map(|t: &T| T::get_heap_size_with_tracker(t, tr));
+            (size + elem_size, tr)
+        });
+        let allocation = self.capacity() * core::mem::size_of::<ConcurrentElement<T>>();
+        (heap + allocation, tracker)
+    }
+}

--- a/crates/get-size2/src/impls/feature/orx_concurrent_vec.rs
+++ b/crates/get-size2/src/impls/feature/orx_concurrent_vec.rs
@@ -2,17 +2,10 @@ use orx_concurrent_vec::{ConcurrentElement, ConcurrentVec, IntoConcurrentPinnedV
 
 use crate::{GetSize, GetSizeTracker};
 
-// `ConcurrentVec<T, P>` is backed by a `PinnedVec` of `ConcurrentElement<T>`
-// slots; each slot is a `ConcurrentElement<T>` (an atomic-state wrapper
-// around `T`) sized at `size_of::<ConcurrentElement<T>>()`. Heap layout
-// matches `Vec`: `capacity()` × per-slot size, plus the recursive heap
-// of each occupied element. This mirrors the `Vec<T>` impl pattern in
-// `collections.rs`.
-//
-// Not counted: per-fragment metadata in the backing `SplitVec`
-// (fragment pointer/length pairs). For a `Doubling` growth strategy
-// this is bounded by ~`log2(capacity)` fragments — tens of bytes total
-// regardless of corpus size.
+// `ConcurrentVec::new()` eagerly allocates an initial fragment, so
+// `capacity()` is nonzero even for an empty vec. Backing `SplitVec`
+// fragment headers are not counted (bounded by a small constant for
+// the default Doubling growth strategy).
 
 impl<T, P> GetSize for ConcurrentVec<T, P>
 where

--- a/crates/get-size2/src/tests/feature.rs
+++ b/crates/get-size2/src/tests/feature.rs
@@ -239,15 +239,12 @@ fn test_orx_concurrent_vec() {
 
     const S: &str = "Hello world";
 
-    // Empty vec: `ConcurrentVec::new()` eagerly allocates an initial
-    // fragment (unlike `Vec::new()`), so heap = capacity × slot size.
     let empty: ConcurrentVec<u32> = ConcurrentVec::new();
     assert_eq!(
         empty.get_heap_size(),
         empty.capacity() * size_of::<ConcurrentElement<u32>>()
     );
 
-    // Copy element after growth: same formula.
     let vec: ConcurrentVec<u32> = ConcurrentVec::new();
     vec.extend(0u32..16);
     assert_eq!(
@@ -255,14 +252,12 @@ fn test_orx_concurrent_vec() {
         vec.capacity() * size_of::<ConcurrentElement<u32>>()
     );
 
-    // Owned element (String): heap is allocation + each String's capacity.
     let vec: ConcurrentVec<String> = ConcurrentVec::new();
     vec.push(String::from(S));
     vec.push(String::from(S));
     let expected = vec.capacity() * size_of::<ConcurrentElement<String>>() + S.len() * 2;
     assert_eq!(vec.get_heap_size(), expected);
 
-    // Tracker-variant: threading a tracker matches the no-tracker path.
     let tracker = StandardTracker::new();
     let (size, _) = vec.get_heap_size_with_tracker(tracker);
     assert_eq!(size, vec.get_heap_size());

--- a/crates/get-size2/src/tests/feature.rs
+++ b/crates/get-size2/src/tests/feature.rs
@@ -232,3 +232,38 @@ fn test_ordermap() {
     set.insert(String::from(VALUE_STR));
     assert!(set.get_heap_size() >= size_of::<String>() + VALUE_STR.len());
 }
+
+#[test]
+fn test_orx_concurrent_vec() {
+    use orx_concurrent_vec::{ConcurrentElement, ConcurrentVec};
+
+    const S: &str = "Hello world";
+
+    // Empty vec: `ConcurrentVec::new()` eagerly allocates an initial
+    // fragment (unlike `Vec::new()`), so heap = capacity × slot size.
+    let empty: ConcurrentVec<u32> = ConcurrentVec::new();
+    assert_eq!(
+        empty.get_heap_size(),
+        empty.capacity() * size_of::<ConcurrentElement<u32>>()
+    );
+
+    // Copy element after growth: same formula.
+    let vec: ConcurrentVec<u32> = ConcurrentVec::new();
+    vec.extend(0u32..16);
+    assert_eq!(
+        vec.get_heap_size(),
+        vec.capacity() * size_of::<ConcurrentElement<u32>>()
+    );
+
+    // Owned element (String): heap is allocation + each String's capacity.
+    let vec: ConcurrentVec<String> = ConcurrentVec::new();
+    vec.push(String::from(S));
+    vec.push(String::from(S));
+    let expected = vec.capacity() * size_of::<ConcurrentElement<String>>() + S.len() * 2;
+    assert_eq!(vec.get_heap_size(), expected);
+
+    // Tracker-variant: threading a tracker matches the no-tracker path.
+    let tracker = StandardTracker::new();
+    let (size, _) = vec.get_heap_size_with_tracker(tracker);
+    assert_eq!(size, vec.get_heap_size());
+}


### PR DESCRIPTION
## Summary

Adds an `orx-concurrent-vec` feature with a `GetSize` impl for `orx_concurrent_vec::ConcurrentVec<T, P>`, following the same pattern as the `dashmap`/`half`/`parking_lot`/`roaring` features.

## Implementation

`ConcurrentVec<T, P>` is backed by a `PinnedVec` of `ConcurrentElement<T>` slots. Heap layout mirrors `Vec`'s:

- **Per-slot allocation**: `capacity() × size_of::<ConcurrentElement<T>>()`. Uses the public `capacity()` method; works for any backing `P` because the slot type is always `ConcurrentElement<T>`.
- **Per-element recursive heap**: iterate via the public `iter()` method, which yields `&ConcurrentElement<T>`; reach `&T` via `ConcurrentElement::map(|t: &T| ...)` to recurse with `T::get_heap_size_with_tracker`.

The impl is generic over both `T: GetSize` and `P: IntoConcurrentPinnedVec<ConcurrentElement<T>>`, matching the upstream impl block's bounds.

**Not counted** (small relative to slot contents and documented at the impl):
- Per-fragment metadata in the backing `SplitVec` (fragment pointer/length pairs). For `Doubling` growth this is `O(log capacity)` fragments — tens of bytes total regardless of corpus size.

## Tests

`test_orx_concurrent_vec` covers:
- Empty `ConcurrentVec::new()` (which eagerly allocates an initial fragment, unlike `Vec::new()`) — heap matches the `capacity × slot-size` formula.
- After `extend` with Copy elements — same formula.
- Owned elements (`String`) — formula plus each element's heap.
- Tracker-variant path with `StandardTracker`.

## Notes

- Feature name `orx-concurrent-vec` matches the published crate name on crates.io.
- `default-features = false` to preserve `no_std`-compatibility for downstream users.
- `IntoConcurrentPinnedVec` and `ConcurrentElement` are re-exported from `orx_concurrent_vec`, so no additional dep is needed.
