### PR TITLE
fix: Track shared DST allocations

### DIFF
--- a/crates/get-size2/src/impls/std_types.rs
+++ b/crates/get-size2/src/impls/std_types.rs
@@ -101,7 +101,7 @@ where
     T: GetSize,
 {
     fn get_heap_size_with_tracker<Tr: GetSizeTracker>(&self, mut tracker: Tr) -> (usize, Tr) {
-        if !tracker.track(Rc::as_ptr(self).cast::<()>()) {
+        if !tracker.track(Self::as_ptr(self).cast::<()>()) {
             return (0, tracker);
         }
 
@@ -117,7 +117,7 @@ where
 
 impl GetSize for Rc<str> {
     fn get_heap_size_with_tracker<T: GetSizeTracker>(&self, mut tracker: T) -> (usize, T) {
-        if !tracker.track(Rc::as_ptr(self).cast::<()>()) {
+        if !tracker.track(Self::as_ptr(self).cast::<()>()) {
             return (0, tracker);
         }
 
@@ -130,7 +130,7 @@ where
     T: GetSize,
 {
     fn get_heap_size_with_tracker<Tr: GetSizeTracker>(&self, mut tracker: Tr) -> (usize, Tr) {
-        if !tracker.track(Arc::as_ptr(self).cast::<()>()) {
+        if !tracker.track(Self::as_ptr(self).cast::<()>()) {
             return (0, tracker);
         }
 
@@ -146,7 +146,7 @@ where
 
 impl GetSize for Arc<str> {
     fn get_heap_size_with_tracker<T: GetSizeTracker>(&self, mut tracker: T) -> (usize, T) {
-        if !tracker.track(Arc::as_ptr(self).cast::<()>()) {
+        if !tracker.track(Self::as_ptr(self).cast::<()>()) {
             return (0, tracker);
         }
 

--- a/crates/get-size2/src/impls/std_types.rs
+++ b/crates/get-size2/src/impls/std_types.rs
@@ -100,7 +100,11 @@ impl<T> GetSize for Rc<[T]>
 where
     T: GetSize,
 {
-    fn get_heap_size_with_tracker<Tr: GetSizeTracker>(&self, tracker: Tr) -> (usize, Tr) {
+    fn get_heap_size_with_tracker<Tr: GetSizeTracker>(&self, mut tracker: Tr) -> (usize, Tr) {
+        if !tracker.track(Rc::as_ptr(self).cast::<()>()) {
+            return (0, tracker);
+        }
+
         let (size, tracker) = self.iter().fold((0, tracker), |(size, tracker), element| {
             let (elem_size, tracker) = T::get_heap_size_with_tracker(element, tracker);
             (size + elem_size, tracker)
@@ -112,7 +116,11 @@ where
 }
 
 impl GetSize for Rc<str> {
-    fn get_heap_size_with_tracker<T: GetSizeTracker>(&self, tracker: T) -> (usize, T) {
+    fn get_heap_size_with_tracker<T: GetSizeTracker>(&self, mut tracker: T) -> (usize, T) {
+        if !tracker.track(Rc::as_ptr(self).cast::<()>()) {
+            return (0, tracker);
+        }
+
         (self.len(), tracker)
     }
 }
@@ -121,7 +129,11 @@ impl<T> GetSize for Arc<[T]>
 where
     T: GetSize,
 {
-    fn get_heap_size_with_tracker<Tr: GetSizeTracker>(&self, tracker: Tr) -> (usize, Tr) {
+    fn get_heap_size_with_tracker<Tr: GetSizeTracker>(&self, mut tracker: Tr) -> (usize, Tr) {
+        if !tracker.track(Arc::as_ptr(self).cast::<()>()) {
+            return (0, tracker);
+        }
+
         let (size, tracker) = self.iter().fold((0, tracker), |(size, tracker), element| {
             let (elem_size, tracker) = T::get_heap_size_with_tracker(element, tracker);
             (size + elem_size, tracker)
@@ -133,7 +145,11 @@ where
 }
 
 impl GetSize for Arc<str> {
-    fn get_heap_size_with_tracker<T: GetSizeTracker>(&self, tracker: T) -> (usize, T) {
+    fn get_heap_size_with_tracker<T: GetSizeTracker>(&self, mut tracker: T) -> (usize, T) {
+        if !tracker.track(Arc::as_ptr(self).cast::<()>()) {
+            return (0, tracker);
+        }
+
         (self.len(), tracker)
     }
 }

--- a/crates/get-size2/src/tests/mod.rs
+++ b/crates/get-size2/src/tests/mod.rs
@@ -285,6 +285,16 @@ fn boxed_slice() {
 
     let arc = Arc::<[u8]>::from([1u8; 10]);
     assert_eq!(arc.get_heap_size(), size_of::<u8>() * arc.len());
+
+    let shared_rc = Rc::<[String]>::from([String::from("hello"), String::from("world")]);
+    let (size, _) =
+        (shared_rc.clone(), shared_rc.clone()).get_heap_size_with_tracker(StandardTracker::new());
+    assert_eq!(size, shared_rc.get_heap_size());
+
+    let shared_arc = Arc::<[String]>::from([String::from("hello"), String::from("world")]);
+    let (size, _) =
+        (shared_arc.clone(), shared_arc.clone()).get_heap_size_with_tracker(StandardTracker::new());
+    assert_eq!(size, shared_arc.get_heap_size());
 }
 
 #[test]
@@ -295,8 +305,14 @@ fn boxed_str() {
     let rc: Rc<str> = "a".to_owned().into();
     assert_eq!(rc.get_heap_size(), size_of::<u8>() * boxed.len());
 
+    let (size, _) = (rc.clone(), rc.clone()).get_heap_size_with_tracker(StandardTracker::new());
+    assert_eq!(size, rc.get_heap_size());
+
     let arc: Arc<str> = "a".to_owned().into();
     assert_eq!(arc.get_heap_size(), size_of::<u8>() * boxed.len());
+
+    let (size, _) = (arc.clone(), arc.clone()).get_heap_size_with_tracker(StandardTracker::new());
+    assert_eq!(size, arc.get_heap_size());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Avoid double-counting shared slice and string allocations for `Rc` and `Arc`.