### PR TITLE
fix: Bump compact_str to 0.10

### DIFF
--- a/crates/get-size2/Cargo.toml
+++ b/crates/get-size2/Cargo.toml
@@ -20,7 +20,7 @@ get-size-derive2 = { workspace = true, optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 chrono = { version = "0.4", default-features = false, optional = true }
 chrono-tz = { version = "0.10", default-features = false, optional = true }
-compact_str = { version = "0.9", default-features = false, optional = true }
+compact_str = { version = "0.10", default-features = false, optional = true }
 dashmap = { version = "6", default-features = false, optional = true }
 half = { version = "2", default-features = false, optional = true }
 hashbrown = { version = "0.17", default-features = false, optional = true }


### PR DESCRIPTION
Bump compact_str to v0.10, which added a direct ToCompactString implementation for str (and so was technically SemVer-breaking).