### PR TITLE
fix: Support 32-bit targets without 64-bit atomics (#54, #56)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,68 +26,61 @@ jobs:
         uses: bnjbvr/cargo-machete@main
 
   build:
-    name: Build
+    name: Build & Test (${{ matrix.name }})
     runs-on: ubuntu-latest
     needs: [typos, cargo-machete]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: 64-bit
+            target: x86_64-unknown-linux-gnu
+          # 32-bit target without 64-bit atomics. Regression-guards the
+          # conditional `AtomicI64`/`AtomicU64` impls (#54) and the
+          # pointer-width-sensitive heap sizes asserted in the tests (#56).
+          - name: 32-bit
+            target: powerpc-unknown-linux-gnu
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      # Installs the Rust target plus a cross linker and a QEMU runner, so
+      # `cargo test --target` both builds and *executes* the emulated 32-bit
+      # binaries. A no-op wrapper for the native host target.
+      - name: Set up toolchain
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ${{ github.ref_name }}
+          shared-key: ${{ github.ref_name }}-${{ matrix.target }}
 
       - name: Debug build
-        run: cargo build
+        run: cargo build --all-features --target ${{ matrix.target }}
 
       - name: Release build
-        run: cargo build --release
-  
-  cross-check:
-    name: Cross-compile (no 64-bit atomics)
-    runs-on: ubuntu-latest
-    needs: [typos, cargo-machete]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      # `powerpc-unknown-linux-gnu` is a 32-bit target without 64-bit atomics,
-      # which regression-guards the conditional `AtomicI64`/`AtomicU64` impls (issue #54).
-      - name: Add 32-bit target
-        run: rustup target add powerpc-unknown-linux-gnu
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ${{ github.ref_name }}
-
-      - name: Check (default features)
-        run: cargo check -p get-size2 --target powerpc-unknown-linux-gnu
-
-      # The `portable-atomic` feature must provide `AtomicU64`/`AtomicI64`
-      # (and 128-bit) on exactly these targets — verify it builds here.
-      - name: Check (portable-atomic feature)
-        run: cargo check -p get-size2 --features portable-atomic --target powerpc-unknown-linux-gnu
-
-  check:
-    name: Lint & Test
-    runs-on: ubuntu-latest
-    needs: [typos, cargo-machete]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ${{ github.ref_name }}
+        run: cargo build --release --all-features --target ${{ matrix.target }}
 
       - name: Test
-        run: cargo test --all
+        run: cargo test --all --all-features --target ${{ matrix.target }}
+
+  check:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: [typos, cargo-machete]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ github.ref_name }}-x86_64-unknown-linux-gnu
 
       - name: Format code
         run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,32 @@ jobs:
       - name: Release build
         run: cargo build --release
   
+  cross-check:
+    name: Cross-compile (no 64-bit atomics)
+    runs-on: ubuntu-latest
+    needs: [typos, cargo-machete]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      # `powerpc-unknown-linux-gnu` is a 32-bit target without 64-bit atomics,
+      # which regression-guards the conditional `AtomicI64`/`AtomicU64` impls (issue #54).
+      - name: Add 32-bit target
+        run: rustup target add powerpc-unknown-linux-gnu
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ github.ref_name }}
+
+      - name: Check
+        run: cargo check -p get-size2 --target powerpc-unknown-linux-gnu
+
   check:
     name: Lint & Test
     runs-on: ubuntu-latest
-    needs: build
+    needs: [typos, cargo-machete]
 
     steps:
       - name: Checkout code
@@ -71,7 +93,7 @@ jobs:
   tarpaulin:
     name: Tarpaulin Coverage
     runs-on: ubuntu-latest
-    needs: [build, check]
+    needs: [typos, cargo-machete]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,13 @@ jobs:
         with:
           shared-key: ${{ github.ref_name }}
 
-      - name: Check
+      - name: Check (default features)
         run: cargo check -p get-size2 --target powerpc-unknown-linux-gnu
+
+      # The `portable-atomic` feature must provide `AtomicU64`/`AtomicI64`
+      # (and 128-bit) on exactly these targets — verify it builds here.
+      - name: Check (portable-atomic feature)
+        run: cargo check -p get-size2 --features portable-atomic --target powerpc-unknown-linux-gnu
 
   check:
     name: Lint & Test

--- a/crates/get-size2/Cargo.toml
+++ b/crates/get-size2/Cargo.toml
@@ -28,6 +28,9 @@ indexmap = { version = "2.14", default-features = false, optional = true }
 ordermap = { version = "1.2", default-features = false, optional = true }
 orx-concurrent-vec = { version = "3.10", default-features = false, optional = true }
 parking_lot = { version = "0.12", default-features = false, optional = true }
+portable-atomic = { version = "1", default-features = false, features = [
+    "fallback",
+], optional = true }
 roaring = { version = "0.11", default-features = false, optional = true }
 smallvec = { version = "1", default-features = false, optional = true }
 thin-vec = { version = "0.2", default-features = false, optional = true }
@@ -47,6 +50,7 @@ get-size2 = { path = ".", features = [
     "ordermap",
     "orx-concurrent-vec",
     "parking_lot",
+    "portable-atomic",
     "roaring",
     "smallvec",
     "thin-vec",
@@ -68,6 +72,7 @@ indexmap = ["dep:indexmap"]
 ordermap = ["dep:ordermap"]
 orx-concurrent-vec = ["dep:orx-concurrent-vec"]
 parking_lot = ["dep:parking_lot"]
+portable-atomic = ["dep:portable-atomic"]
 roaring = ["dep:roaring"]
 smallvec = ["dep:smallvec"]
 thin-vec = ["dep:thin-vec"]

--- a/crates/get-size2/src/impls/feature/mod.rs
+++ b/crates/get-size2/src/impls/feature/mod.rs
@@ -22,6 +22,8 @@ mod ordermap;
 mod orx_concurrent_vec;
 #[cfg(feature = "parking_lot")]
 mod parking_lot;
+#[cfg(feature = "portable-atomic")]
+mod portable_atomic;
 #[cfg(feature = "roaring")]
 mod roaring;
 #[cfg(feature = "smallvec")]

--- a/crates/get-size2/src/impls/feature/portable_atomic.rs
+++ b/crates/get-size2/src/impls/feature/portable_atomic.rs
@@ -1,0 +1,23 @@
+use crate::GetSize;
+
+// `portable-atomic` provides atomic types that work on every target, including
+// 32-bit ones (e.g. ppc32) that lack native 64-bit atomics and therefore have
+// no `std::sync::atomic::AtomicU64`/`AtomicI64` (see issue #54). These impls let
+// crates that reach for `portable_atomic` on such targets still measure size.
+//
+// Like their std counterparts in `impls/primitives.rs`, these are stack-only
+// types, so the default `get_heap_size` (returning 0) is correct.
+
+impl GetSize for portable_atomic::AtomicBool {}
+impl GetSize for portable_atomic::AtomicI8 {}
+impl GetSize for portable_atomic::AtomicI16 {}
+impl GetSize for portable_atomic::AtomicI32 {}
+impl GetSize for portable_atomic::AtomicI64 {}
+impl GetSize for portable_atomic::AtomicI128 {}
+impl GetSize for portable_atomic::AtomicIsize {}
+impl GetSize for portable_atomic::AtomicU8 {}
+impl GetSize for portable_atomic::AtomicU16 {}
+impl GetSize for portable_atomic::AtomicU32 {}
+impl GetSize for portable_atomic::AtomicU64 {}
+impl GetSize for portable_atomic::AtomicU128 {}
+impl GetSize for portable_atomic::AtomicUsize {}

--- a/crates/get-size2/src/impls/primitives.rs
+++ b/crates/get-size2/src/impls/primitives.rs
@@ -5,9 +5,13 @@ use std::num::{
     NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize,
 };
 use std::sync::atomic::{
-    AtomicBool, AtomicI8, AtomicI16, AtomicI32, AtomicI64, AtomicIsize, AtomicU8, AtomicU16,
-    AtomicU32, AtomicU64, AtomicUsize, Ordering,
+    AtomicBool, AtomicI8, AtomicI16, AtomicI32, AtomicIsize, AtomicU8, AtomicU16, AtomicU32,
+    AtomicUsize, Ordering,
 };
+// `AtomicI64`/`AtomicU64` are only available on targets that support 64-bit atomics.
+// 32-bit targets (e.g. ppc32) lack them, so they must be gated. See issue #54.
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::{AtomicI64, AtomicU64};
 use std::time::{Duration, Instant, SystemTime};
 
 use crate::GetSize;
@@ -46,11 +50,13 @@ impl GetSize for AtomicBool {}
 impl GetSize for AtomicI8 {}
 impl GetSize for AtomicI16 {}
 impl GetSize for AtomicI32 {}
+#[cfg(target_has_atomic = "64")]
 impl GetSize for AtomicI64 {}
 impl GetSize for AtomicIsize {}
 impl GetSize for AtomicU8 {}
 impl GetSize for AtomicU16 {}
 impl GetSize for AtomicU32 {}
+#[cfg(target_has_atomic = "64")]
 impl GetSize for AtomicU64 {}
 impl GetSize for AtomicUsize {}
 impl GetSize for Ordering {}

--- a/crates/get-size2/src/tests/feature.rs
+++ b/crates/get-size2/src/tests/feature.rs
@@ -339,3 +339,26 @@ fn test_orx_concurrent_vec() {
     let (size, _) = vec.get_heap_size_with_tracker(tracker);
     assert_eq!(size, vec.get_heap_size());
 }
+
+#[test]
+fn test_portable_atomic() {
+    // Atomics are stack-only, so heap size is 0 and total size equals the
+    // type's own size. `AtomicU64`/`AtomicI64`/`AtomicU128`/`AtomicI128` are
+    // the whole point of the feature: they exist here even on targets without
+    // native 64/128-bit atomics.
+    let u64 = portable_atomic::AtomicU64::new(1);
+    assert_eq!(u64.get_heap_size(), 0);
+    assert_eq!(u64.get_size(), size_of::<portable_atomic::AtomicU64>());
+
+    let i64 = portable_atomic::AtomicI64::new(-1);
+    assert_eq!(i64.get_heap_size(), 0);
+    assert_eq!(i64.get_size(), size_of::<portable_atomic::AtomicI64>());
+
+    let u128 = portable_atomic::AtomicU128::new(1);
+    assert_eq!(u128.get_heap_size(), 0);
+    assert_eq!(u128.get_size(), size_of::<portable_atomic::AtomicU128>());
+
+    let b = portable_atomic::AtomicBool::new(true);
+    assert_eq!(b.get_heap_size(), 0);
+    assert_eq!(b.get_size(), size_of::<portable_atomic::AtomicBool>());
+}

--- a/crates/get-size2/src/tests/feature.rs
+++ b/crates/get-size2/src/tests/feature.rs
@@ -321,6 +321,7 @@ fn test_roaring_treemap() {
     assert_eq!(size, tm.get_heap_size());
 }
 
+#[test]
 fn test_orx_concurrent_vec() {
     use orx_concurrent_vec::{ConcurrentElement, ConcurrentVec};
 

--- a/crates/get-size2/src/tests/feature.rs
+++ b/crates/get-size2/src/tests/feature.rs
@@ -174,7 +174,12 @@ fn test_indexmap() {
     let hasher = RandomState::new();
 
     let mut map = indexmap::IndexMap::with_capacity_and_hasher(1, hasher);
-    assert_eq!(map.get_heap_size(), 40);
+    // The allocation is `capacity * size_of::<(K, V)>()`, which is pointer-width
+    // dependent (40 bytes on 64-bit, 20 on 32-bit) — don't hard-code it.
+    assert_eq!(
+        map.get_heap_size(),
+        map.capacity() * size_of::<(&'static str, String)>()
+    );
     map.insert(VALUE_STR, String::from(VALUE_STR));
     assert!(map.get_heap_size() >= size_of::<(&'static str, String)>() + VALUE_STR.len());
 
@@ -218,7 +223,12 @@ fn test_ordermap() {
     let hasher = RandomState::new();
 
     let mut map = ordermap::OrderMap::with_capacity_and_hasher(1, hasher);
-    assert_eq!(map.get_heap_size(), 40);
+    // The allocation is `capacity * size_of::<(K, V)>()`, which is pointer-width
+    // dependent (40 bytes on 64-bit, 20 on 32-bit) — don't hard-code it.
+    assert_eq!(
+        map.get_heap_size(),
+        map.capacity() * size_of::<(&'static str, String)>()
+    );
     map.insert(VALUE_STR, String::from(VALUE_STR));
     assert!(map.get_heap_size() >= size_of::<(&'static str, String)>() + VALUE_STR.len());
 


### PR DESCRIPTION
`AtomicI64`/`AtomicU64` only exist on targets that support 64-bit atomics. 32-bit targets such as ppc32 lack them, which broke both the build and the test suite. This addresses #54 and #56.

### Fix the build (#54)
Importing and implementing `GetSize` for `AtomicI64`/`AtomicU64` unconditionally failed to compile on targets without 64-bit atomics. Gate the imports and impls behind `#[cfg(target_has_atomic = "64")]`, matching how `std` conditionally defines these types.

### Fix the tests (#56)
`test_indexmap` and `test_ordermap` hard-coded the initial allocation as `40` bytes, which assumes 64-bit pointers (it is `20` on 32-bit). Compute the expectation the same way the impl does — `capacity() * size_of::<(K, V)>()` — so it holds on any pointer width.

### Add a `portable-atomic` feature
Optional feature providing `GetSize` impls for the `portable_atomic` bool/integer atomics, including the 64- and 128-bit types that exist on *every* target. This lets crates that adopt `portable_atomic` to get 64-bit atomics on targets like ppc32 still measure their size. The `fallback` feature is enabled so those emulated types are available.

### Test on 32-bit in CI
The build job is now a matrix over `x86_64-unknown-linux-gnu` (64-bit) and `powerpc-unknown-linux-gnu` (32-bit, no native 64-bit atomics). It builds and runs the full test suite on each, with the 32-bit binaries executed under QEMU via `taiki-e/setup-cross-toolchain-action` — so both regressions are caught by actually running the tests. Also registers `test_orx_concurrent_vec`, which was missing its `#[test]` attribute and never ran.

> **Note for merge:** CI check names changed (`Build` → `Build & Test (64-bit)`/`Build & Test (32-bit)`, `Lint & Test` → `Lint`); branch-protection required checks need updating to match.

Fixes #54 #56
